### PR TITLE
Migrate React.PropTypes to prop-types

### DIFF
--- a/__tests__/components/Wizard.spec.jsx
+++ b/__tests__/components/Wizard.spec.jsx
@@ -12,7 +12,8 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
 
 import { Wizard } from '../../src';

--- a/examples/Animated.jsx
+++ b/examples/Animated.jsx
@@ -13,7 +13,7 @@
  */
 
 import React from 'react';
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { Wizard, Step, Steps, Navigation } from '../src';
 import FirstStep from './components/FirstStep';
 import SecondStep from './components/SecondStep';

--- a/examples/navigation/Next.jsx
+++ b/examples/navigation/Next.jsx
@@ -12,7 +12,8 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const Next = ({ className, disabled, label, next }) =>
   <button className={className} onClick={next} disabled={disabled}>{label}</button>;

--- a/examples/navigation/Previous.jsx
+++ b/examples/navigation/Previous.jsx
@@ -12,7 +12,8 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const Previous = ({ className, disabled, label, previous }) =>
   <button className={className} onClick={previous} disabled={disabled}>{label}</button>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-albus",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React component library for building declarative multi-step flows.",
   "files": [
     "lib"
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "history": "^4.6.0",
+    "prop-types": "^15.5.8",
     "react": "^15.4.2"
   },
   "devDependencies": {
@@ -59,10 +60,10 @@
     "import-glob-loader": "^1.1.0",
     "jest": "^19.0.0",
     "node-sass": "^4.5.0",
-    "react-addons-css-transition-group": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.0.1",
+    "react-dom": "^15.5.4",
     "react-router-dom": "^4.0.0",
+    "react-test-renderer": "^15.5.4",
+    "react-transition-group": "^1.1.1",
     "rimraf": "^2.5.2",
     "sass-loader": "^6.0.2",
     "style-loader": "^0.13.2",

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -12,7 +12,8 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import withWizard from '../withWizard';
 

--- a/src/components/Step.jsx
+++ b/src/components/Step.jsx
@@ -12,7 +12,8 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const Step = ({ children, className }) => <div className={className}>{children}</div>;
 

--- a/src/components/Steps.jsx
+++ b/src/components/Steps.jsx
@@ -12,7 +12,8 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Steps extends Component {
   componentWillMount() {

--- a/src/components/Wizard.jsx
+++ b/src/components/Wizard.jsx
@@ -12,7 +12,8 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { createMemoryHistory } from 'history';
 import fixPath from '../utils';
 

--- a/src/withWizard.js
+++ b/src/withWizard.js
@@ -12,7 +12,8 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const withWizard = (component) => {
   const WithWizard = (props, { wizard }) =>


### PR DESCRIPTION
Migrated from `React.PropTypes` to `prop-types` after [React 15.5 changes](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html).