### PR TITLE
Added an option to match ids loosely

### DIFF
--- a/__tests__/components/Wizard.spec.jsx
+++ b/__tests__/components/Wizard.spec.jsx
@@ -162,4 +162,45 @@ describe('Wizard', () => {
       mounted.unmount();
     });
   });
+
+  describe('with existing history and non-strict route matching', () => {
+    const history = {
+      replace: () => null,
+      listen: () => () => null,
+      location: {
+        pathname: '/slytherin/snape',
+      },
+    };
+
+    let wizard;
+    let mounted;
+    beforeEach(() => {
+      mounted = mount(
+        <Wizard history={history} exactMatch={false}>
+          <WithWizard>
+            {prop => {
+              wizard = prop;
+              return null;
+            }}
+          </WithWizard>
+          <Steps>
+            <Step id="gryffindor">
+              <div />
+            </Step>
+            <Step id="slytherin">
+              <div />
+            </Step>
+          </Steps>
+        </Wizard>
+      );
+    });
+
+    it('matches the step', () => {
+      expect(wizard.step).toEqual({ id: 'slytherin' });
+    });
+
+    afterEach(() => {
+      mounted.unmount();
+    });
+  });
 });

--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -72,7 +72,10 @@ class Wizard extends Component {
 
   pathToStep = pathname => {
     const id = pathname.replace(this.basename, '');
-    const [step] = this.state.steps.filter(s => s.id === id);
+    const [step] = this.state.steps.filter(
+      s => (this.props.exactMatch ? s.id === id : id.startsWith(s.id))
+    );
+
     return step || this.state.step;
   };
 
@@ -116,6 +119,7 @@ Wizard.propTypes = {
     replace: PropTypes.func,
   }),
   onNext: PropTypes.func,
+  exactMatch: PropTypes.bool,
 };
 
 Wizard.defaultProps = {
@@ -123,6 +127,7 @@ Wizard.defaultProps = {
   history: null,
   onNext: null,
   render: null,
+  exactMatch: true,
 };
 
 Wizard.childContextTypes = {


### PR DESCRIPTION
This PR adds an option to the wizard to match routes loosely by matching the beginning of the url instead of the entire thing.

**Example:**

```javascript
<Wizard history={history} exactMatch={false}>
```
```javascript
<Step id="step1">
```
Expected routes:
`/step1/add`
`/step1/assign`
`/step1/login`
