### PR TITLE
feat(wizard): canNavigateTo function

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ In addition to `id`, any additional props added to `<Step>` will be available on
 
 `<WithWizard>` is an alias for `<Step>` that can be used to access [`context.wizard`](#contextwizard) anywhere within the `<Wizard>` tree.
 
+##### `canNavigateTo(wizard)`: function *(optional)*
+A function that will be called by `<Wizard>` to determine if the navigation targeting a specific step can happen or not.
+Useful when there are related steps and you don't want your user to jump/skip steps.
+
+##### Params
+
+* `wizard` (object): The [`context.wizard`](#contextwizard) object.
+
+If you do not pass an `canNavigateTo` prop, the default behaviour is preserved, the navigation is never prevented.
 ---
 
 ### `withWizard()`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-albus",
-  "version": "2.0.0",
+  "name": "@shipdigital/react-albus",
+  "version": "2.1.0",
   "description": "React component library for building declarative multi-step flows.",
   "files": [
     "lib"
@@ -11,12 +11,12 @@
     "start": "webpack-dev-server --port 3000 --inline --hot --open",
     "test": "jest",
     "lint": "eslint --ignore-path .eslintignore --ext .js --ext .jsx ./",
-    "prebuild": "npm run clean && npm run lint",
+    "prebuild": "npm run clean",
     "build": "babel src -d lib --copy-files",
     "posttest": "npm run lint",
     "prepublish": "npm run build"
   },
-  "repository": "americanexpress/react-albus",
+  "repository": "shipdigital/react-albus",
   "keywords": [
     "react",
     "react-component",
@@ -63,12 +63,12 @@
     "jest": "^21.2.1",
     "node-sass": "^4.5.0",
     "prettier": "^1.6.1",
+    "rc-progress": "^2.2.5",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router-dom": "^4.0.0",
     "react-test-renderer": "^16.0.0",
     "react-transition-group": "^2.2.1",
-    "rc-progress": "^2.2.5",
     "rimraf": "^2.5.2",
     "sass-loader": "^6.0.2",
     "style-loader": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@shipdigital/react-albus",
+  "name": "react-albus",
   "version": "2.1.0",
   "description": "React component library for building declarative multi-step flows.",
   "files": [
@@ -11,12 +11,12 @@
     "start": "webpack-dev-server --port 3000 --inline --hot --open",
     "test": "jest",
     "lint": "eslint --ignore-path .eslintignore --ext .js --ext .jsx ./",
-    "prebuild": "npm run clean",
+    "prebuild": "npm run clean && npm run lint",
     "build": "babel src -d lib --copy-files",
     "posttest": "npm run lint",
     "prepublish": "npm run build"
   },
-  "repository": "shipdigital/react-albus",
+  "repository": "americanexpress/react-albus",
   "keywords": [
     "react",
     "react-component",

--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -41,9 +41,17 @@ class Wizard extends Component {
   }
 
   componentWillMount() {
-    this.unlisten = this.history.listen(({ pathname }) =>
-      this.setState({ step: this.pathToStep(pathname) })
-    );
+    this.unlisten = this.history.listen(({ pathname }) => {
+      const currentStep = this.state.step;
+      const targetStep = this.pathToStep(pathname);
+      const canNavigate = targetStep.canNavigateTo || (() => true);
+      if (
+        currentStep.id === null ||
+        (currentStep.id !== null && canNavigate(this.getChildContext().wizard))
+      ) {
+        this.setState({ step: targetStep });
+      }
+    });
 
     if (this.props.onNext) {
       const { init, ...wizard } = this.getChildContext().wizard;
@@ -79,7 +87,8 @@ class Wizard extends Component {
   init = steps => {
     this.setState({ steps }, () => {
       const step = this.pathToStep(this.history.location.pathname);
-      if (step.id) {
+      const canNavigate = step.canNavigateTo || (() => true);
+      if (step.id !== null && canNavigate(this.getChildContext().wizard)) {
         this.setState({ step });
       } else {
         this.history.replace(`${this.basename}${this.ids[0]}`);


### PR DESCRIPTION
Added support for an optional function `canNavigateTo(wizard)` to the **Step** component.
It allows the user to specify logic used to disallow hot-linking steps