### PR TITLE
Add search params (query params) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A higher order component that adds [`context.wizard`](#contextwizard) as a `wiza
 * `step` (object): Describes the current step with structure: `{ id: string }`.
 * `steps` (array): Array of `step` objects in the order they were declared within `<Steps>`.
 * `history` (object): The backing [`history`](https://github.com/ReactTraining/history#properties) object.
+* `preserveSearch` (bool): Determines if react-albus should preserve search params (query string params) when it handles history navigation
 * `next()` (function): Moves to the next step in order.
 * `previous()` (function): Moves to the previous step in order.
 * `go(n)` (function): Moves `n` steps in history.

--- a/__tests__/components/Wizard.spec.jsx
+++ b/__tests__/components/Wizard.spec.jsx
@@ -162,4 +162,48 @@ describe('Wizard', () => {
       mounted.unmount();
     });
   });
+
+  describe('with existing history and preserving search params', () => {
+    const history = {
+      replace: () => null,
+      listen: () => () => null,
+      location: {
+        pathname: '/gryffindor',
+        search: '?foo=bar',
+      },
+    };
+
+    let wizard;
+    let mounted;
+    beforeEach(() => {
+      mounted = mount(
+        <Wizard history={history} preserveSearch={true}>
+          <WithWizard>
+            {prop => {
+              wizard = prop;
+              return null;
+            }}
+          </WithWizard>
+          <Steps>
+            <Step id="gryffindor">
+              <div />
+            </Step>
+            <Step id="slytherin">
+              <div />
+            </Step>
+          </Steps>
+        </Wizard>
+      );
+    });
+
+    it('call next and ensure url params are still in the url', () => {
+      wizard.history.push = jest.fn();
+      wizard.next();
+      expect(wizard.history.push).toBeCalledWith('/slytherin?foo=bar');
+    });
+
+    afterEach(() => {
+      mounted.unmount();
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prebuild": "npm run clean && npm run lint",
     "build": "babel src -d lib --copy-files",
     "posttest": "npm run lint",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "prepare": "npm run build"
   },
   "repository": "americanexpress/react-albus",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "prebuild": "npm run clean && npm run lint",
     "build": "babel src -d lib --copy-files",
     "posttest": "npm run lint",
-    "prepublish": "npm run build",
-    "prepare": "npm run build"
+    "prepublish": "npm run build"
   },
   "repository": "americanexpress/react-albus",
   "keywords": [

--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -59,6 +59,13 @@ class Wizard extends Component {
     return `${this.props.basename}/`;
   }
 
+  get historySuffix() {
+    return this.props.preserveSearch
+      ? this.history.location.search
+      : ''
+    ;
+  }
+
   get ids() {
     return this.state.steps.map(s => s.id);
   }
@@ -82,13 +89,13 @@ class Wizard extends Component {
       if (step.id) {
         this.setState({ step });
       } else {
-        this.history.replace(`${this.basename}${this.ids[0]}`);
+        this.history.replace(`${this.basename}${this.ids[0]}${this.historySuffix}`);
       }
     });
   };
 
-  push = (step = this.nextStep) => this.history.push(`${this.basename}${step}`);
-  replace = (step = this.nextStep) => this.history.replace(`${this.basename}${step}`);
+  push = (step = this.nextStep) => this.history.push(`${this.basename}${step}${this.historySuffix}`);
+  replace = (step = this.nextStep) => this.history.replace(`${this.basename}${step}${this.historySuffix}`);
 
   next = () => {
     if (this.props.onNext) {
@@ -106,6 +113,7 @@ class Wizard extends Component {
 
 Wizard.propTypes = {
   basename: PropTypes.string,
+  preserveSearch: PropTypes.bool,
   history: PropTypes.shape({
     entries: PropTypes.array,
     go: PropTypes.func,
@@ -120,6 +128,7 @@ Wizard.propTypes = {
 
 Wizard.defaultProps = {
   basename: '',
+  preserveSearch: false,
   history: null,
   onNext: null,
   render: null,

--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -60,10 +60,7 @@ class Wizard extends Component {
   }
 
   get historySuffix() {
-    return this.props.preserveSearch
-      ? this.history.location.search
-      : ''
-    ;
+    return this.props.preserveSearch ? this.history.location.search : '';
   }
 
   get ids() {
@@ -94,8 +91,10 @@ class Wizard extends Component {
     });
   };
 
-  push = (step = this.nextStep) => this.history.push(`${this.basename}${step}${this.historySuffix}`);
-  replace = (step = this.nextStep) => this.history.replace(`${this.basename}${step}${this.historySuffix}`);
+  push = (step = this.nextStep) =>
+    this.history.push(`${this.basename}${step}${this.historySuffix}`);
+  replace = (step = this.nextStep) =>
+    this.history.replace(`${this.basename}${step}${this.historySuffix}`);
 
   next = () => {
     if (this.props.onNext) {


### PR DESCRIPTION
This option keeps URL search params in the history and prevents them from being overwritten when react-albus handles navigation. This handles issue #36. 

This feature is very useful when you have a unique link identifier for a user and you want to preserve it in the URL so they can share it with others or return back to it with that data still present in the url.