### PR TITLE
Warning: componentWillMount has been renamed, and is not recommended for use

### DIFF
--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -16,7 +16,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class Steps extends Component {
-  componentWillMount() {
+  componentDidMount() {
     const steps = React.Children.map(
       this.props.children,
       ({ props: { children, render, ...config } }) => config

--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -40,7 +40,7 @@ class Wizard extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.unlisten = this.history.listen(({ pathname }) =>
       this.setState({ step: this.pathToStep(pathname) })
     );


### PR DESCRIPTION
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Steps, Wizard
