### PR TITLE
chore(codeowners): add codeowners and npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,22 @@
+# test
+__tests__
+.jest-cache
+test-results
+
+# meta
+.eslintrc.json
+.eslintignore
+.babelrc
+*.tgz
+.editorconfig
+index.dev.js
+index.html
+
+# examples
+examples/
+
+# docs
+docs/
+
+# ci-cd
+.travis.yml

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/en/articles/about-code-owners
+
+* @americanexpress/one


### PR DESCRIPTION
This adds `CODEOWNERS` as well as a `.npmignore` file that ignores it along with other files during the bundling of the lib.