### PR TITLE
Fix: Update previous method to work with non-linear steps

### DIFF
--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -67,6 +67,10 @@ class Wizard extends Component {
     return this.ids[this.ids.indexOf(this.state.step.id) + 1];
   }
 
+  get previousStep() {
+    return this.ids[this.ids.indexOf(this.state.step.id) - 1];
+  }
+
   history = this.props.history || createMemoryHistory();
   steps = [];
 
@@ -92,6 +96,7 @@ class Wizard extends Component {
 
   push = (step = this.nextStep) => this.history.push(`${this.basename}${step}`);
   replace = (step = this.nextStep) => this.history.replace(`${this.basename}${step}`);
+  pushPrevious = (step = this.previousStep) => this.history.push(`${this.basename}${step}`);
 
   next = () => {
     if (this.props.onNext) {
@@ -102,7 +107,7 @@ class Wizard extends Component {
   };
 
   previous = () => {
-    this.history.goBack();
+    this.pushPrevious();
   };
 
   render() {

--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -32,7 +32,7 @@ class Wizard extends Component {
         history: this.history,
         init: this.init,
         next: this.next,
-        previous: this.history.goBack,
+        previous: this.previous,
         push: this.push,
         replace: this.replace,
         ...this.state,
@@ -99,6 +99,10 @@ class Wizard extends Component {
     } else {
       this.push();
     }
+  };
+
+  previous = () => {
+    this.history.goBack();
   };
 
   render() {


### PR DESCRIPTION
Fix https://github.com/americanexpress/react-albus/issues/57

Using `history.goBack` in `previous` relies on the assumption that the previously visited step was before the current one. This assumption breaks when steps are non-linear, and a user can jump directly to any following or previous step.