### PR TITLE
Feature: Add new set method to navigate directly to a particular step

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ A higher order component that adds [`context.wizard`](#contextwizard) as a `wiza
 * `go(n)` (function): Moves `n` steps in history.
 * `push(id)` (function): Pushes the step with corresponding `id` onto history.
 * `replace(id)` (function): Replaces the current step in history with the step with corresponding `id`.
+* `set(id)` (function): Move to step `id`.
 
 ## 📘 Usage with React Router
 

--- a/__tests__/__snapshots__/wizardShape.spec.jsx.snap
+++ b/__tests__/__snapshots__/wizardShape.spec.jsx.snap
@@ -9,6 +9,7 @@ Object {
     "previous": "squawk",
     "push": "squawk",
     "replace": "squawk",
+    "set": "squawk",
     "step": Object {
       "id": "squawk",
     },

--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -29,6 +29,7 @@ class Wizard extends Component {
     return {
       wizard: {
         go: this.history.go,
+        set: this.set,
         history: this.history,
         init: this.init,
         next: this.next,
@@ -90,8 +91,9 @@ class Wizard extends Component {
     });
   };
 
-  push = (step = this.nextStep) => this.history.push(`${this.basename}${step}`);
-  replace = (step = this.nextStep) => this.history.replace(`${this.basename}${step}`);
+  set = step => this.history.push(`${this.basename}${step}`);
+  push = (step = this.nextStep) => this.set(step);
+  replace = (step = this.nextStep) => this.set(step);
 
   next = () => {
     if (this.props.onNext) {

--- a/src/wizardShape.js
+++ b/src/wizardShape.js
@@ -16,6 +16,7 @@ import PropTypes from 'prop-types';
 
 export default PropTypes.shape({
   go: PropTypes.func.isRequired,
+  set: PropTypes.func.isRequired,
   history: PropTypes.object.isRequired,
   next: PropTypes.func.isRequired,
   previous: PropTypes.func.isRequired,


### PR DESCRIPTION
Add a new `set(id)` method, to navigate straight to a specific step (using the id).

This can be useful when doing non-linear wizard, where a user can do partial form submission.