### PR TITLE
Issue #73 take advantage of browser-level lazy-loading for iframes to…

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -41,35 +41,35 @@
     <div class="card margin-responsive-b">
       <div class="pad">
         <h1 class="heading-5 dls-accent-blue-02 margin-b">Start Simple</h1>
-        <iframe src="https://codesandbox.io/embed/github/americanexpress/react-albus/tree/master/examples/start-simple" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+        <iframe loading="lazy" src="https://codesandbox.io/embed/github/americanexpress/react-albus/tree/master/examples/start-simple" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
           sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
       </div>
     </div>
     <div class="card margin-responsive-b">
       <div class="pad">
         <h1 class="heading-5 dls-accent-blue-02 margin-b">Add Routing</h1>
-        <iframe src="https://codesandbox.io/embed/github/americanexpress/react-albus/tree/master/examples/add-routing" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+        <iframe loading="lazy" src="https://codesandbox.io/embed/github/americanexpress/react-albus/tree/master/examples/add-routing" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
           sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
       </div>
     </div>
     <div class="card margin-responsive-b">
       <div class="pad">
         <h1 class="heading-5 dls-accent-blue-02 margin-b">Add Animation</h1>
-        <iframe src="https://codesandbox.io/embed/github/americanexpress/react-albus/tree/master/examples/add-animation" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+        <iframe loading="lazy" src="https://codesandbox.io/embed/github/americanexpress/react-albus/tree/master/examples/add-animation" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
           sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
       </div>
     </div>
     <div class="card">
       <div class="pad">
         <h1 class="heading-5 dls-accent-blue-02 margin-b">Add Progress Bar</h1>
-        <iframe src="https://codesandbox.io/embed/github/americanexpress/react-albus/tree/master/examples/add-progress-bar" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+        <iframe loading="lazy" src="https://codesandbox.io/embed/github/americanexpress/react-albus/tree/master/examples/add-progress-bar" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
           sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
       </div>
     </div>
     <div class="card">
       <div class="pad">
         <h1 class="heading-5 dls-accent-blue-02 margin-b">Skip A Step</h1>
-        <iframe src="https://codesandbox.io/embed/github/americanexpress/react-albus/tree/master/examples/skip-a-step" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+        <iframe loading="lazy" src="https://codesandbox.io/embed/github/americanexpress/react-albus/tree/master/examples/skip-a-step" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
           sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
       </div>
     </div>


### PR DESCRIPTION
… speed up examples page. 

Rather than breaking code sandbox examples out into their own pages as suggested in the open issue, take advantage of native iframe lazy loading, introduced by Chrome in July 2020 => https://web.dev/iframe-lazy-loading/