### PR TITLE
fix: restore replace method original behaviour

### DIFF
--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -97,7 +97,7 @@ class Wizard extends Component {
 
   set = step => this.history.push(`${this.basename}${step}`);
   push = (step = this.nextStep) => this.set(step);
-  replace = (step = this.nextStep) => this.set(step);
+  replace = (step = this.nextStep) => this.history.replace(`${this.basename}${step}`);
   pushPrevious = (step = this.previousStep) => this.set(step);
 
   next = () => {


### PR DESCRIPTION
Revert change to replace in https://github.com/americanexpress/react-albus/pull/83/commits/8eb6bbd6aabb4002e4865d7e715b3a7fe9c11770

