### PR TITLE
Make peerDependencies future proof

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "webpack-dev-server": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0"
+    "react": ">=15.0.0",
+    "react-dom": ">=15.0.0"
   }
 }


### PR DESCRIPTION
This doesn't require any action when a new version of React is released but react-albus could break if React has breaking changes.

An other option is

```
    "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
```

but please note I have only tested with React 17