### PR TITLE
feat: add `preserveQuery` option to Wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A higher order component that adds [`context.wizard`](#contextwizard) as a `wiza
 * `step` (object): Describes the current step with structure: `{ id: string }`.
 * `steps` (array): Array of `step` objects in the order they were declared within `<Steps>`.
 * `history` (object): The backing [`history`](https://github.com/ReactTraining/history#properties) object.
+* `preserveQuery` (boolean): Whether or not to preserve the query string when navigating between steps.
 * `next()` (function): Moves to the next step in order.
 * `previous()` (function): Moves to the previous step in order.
 * `go(n)` (function): Moves `n` steps in history.

--- a/__tests__/components/Wizard.spec.jsx
+++ b/__tests__/components/Wizard.spec.jsx
@@ -203,4 +203,130 @@ describe('Wizard', () => {
       mounted.unmount();
     });
   });
+
+  describe('with existing history and preserving search params', () => {
+    let wizard;
+    let mounted;
+
+    const mockReplace = jest.fn();
+    const mockPush = jest.fn();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('initially at /gryffindor with ?foo=bar', () => {
+      const history = {
+        replace: mockReplace,
+        listen: () => () => null,
+        location: {
+          pathname: '/gryffindor',
+          search: '?foo=bar',
+        },
+      };
+
+      beforeEach(() => {
+        mounted = mount(
+          <Wizard history={history} preserveQuery={true}>
+            <WithWizard>
+              {prop => {
+                wizard = prop;
+                return null;
+              }}
+            </WithWizard>
+            <Steps>
+              <Step id="gryffindor">
+                <div />
+              </Step>
+              <Step id="slytherin">
+                <div />
+              </Step>
+              <Step id="hufflepuff">
+                <div />
+              </Step>
+            </Steps>
+          </Wizard>
+        );
+      });
+
+      it('should preserve query when calling next', () => {
+        wizard.history.push = mockPush;
+        wizard.next();
+        expect(mockPush).toBeCalledWith({ pathname: '/slytherin', search: '?foo=bar' });
+      });
+
+      it('should preserve query when calling replace', () => {
+        wizard.replace('hufflepuff');
+        expect(mockReplace).toBeCalledWith({ pathname: '/hufflepuff', search: '?foo=bar' });
+      });
+
+      it('should produce the correct URL string when preserving search params', () => {
+        wizard.replace('hufflepuff');
+        const callArgs = mockReplace.mock.calls[0][0];
+        const actualURL = `${callArgs.pathname}${callArgs.search}`;
+        expect(actualURL).toBe('/hufflepuff?foo=bar');
+      });
+
+      it('should not add search params if none existed initially when calling push', () => {
+        history.location.search = '';
+        wizard.push('hufflepuff');
+        expect(mockPush).toBeCalledWith({ pathname: '/hufflepuff', search: '' });
+      });
+    });
+
+    describe('initially at /slytherin with ?quidditch=true', () => {
+      const history = {
+        replace: mockReplace,
+        listen: () => () => null,
+        location: {
+          pathname: '/slytherin',
+          search: '?quidditch=true',
+        },
+      };
+
+      beforeEach(() => {
+        mounted = mount(
+          <Wizard history={history} preserveQuery={true}>
+            <WithWizard>
+              {prop => {
+                wizard = prop;
+                return null;
+              }}
+            </WithWizard>
+            <Steps>
+              <Step id="gryffindor">
+                <div />
+              </Step>
+              <Step id="slytherin">
+                <div />
+              </Step>
+              <Step id="hufflepuff">
+                <div />
+              </Step>
+            </Steps>
+          </Wizard>
+        );
+      });
+
+      it('should preserve query when calling next', () => {
+        wizard.history.push = jest.fn();
+        wizard.next();
+        expect(wizard.history.push).toBeCalledWith({
+          pathname: '/hufflepuff',
+          search: '?quidditch=true',
+        });
+      });
+
+      it('should produce the correct URL string when preserving search params', () => {
+        wizard.replace('gryffindor');
+        const callArgs = mockReplace.mock.calls[0][0];
+        const actualURL = `${callArgs.pathname}${callArgs.search}`;
+        expect(actualURL).toBe('/gryffindor?quidditch=true');
+      });
+    });
+
+    afterEach(() => {
+      mounted.unmount();
+    });
+  });
 });

--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -97,9 +97,19 @@ class Wizard extends Component {
     });
   };
 
-  set = step => this.history.push(`${this.basename}${step}`);
+  constructPath = step => {
+    if (this.props.preserveQuery) {
+      return {
+        ...this.history.location,
+        pathname: `${this.basename}${step}`,
+      };
+    }
+    return `${this.basename}${step}`;
+  };
+
   push = (step = this.nextStep) => this.set(step);
-  replace = (step = this.nextStep) => this.history.replace(`${this.basename}${step}`);
+  set = step => this.history.push(this.constructPath(step));
+  replace = (step = this.nextStep) => this.history.replace(this.constructPath(step));
   pushPrevious = (step = this.previousStep) => this.set(step);
 
   next = () => {
@@ -122,6 +132,7 @@ class Wizard extends Component {
 
 Wizard.propTypes = {
   basename: PropTypes.string,
+  preserveQuery: PropTypes.bool,
   history: PropTypes.shape({
     // disabling due to lost context
     // eslint-disable-next-line react/forbid-prop-types
@@ -141,6 +152,7 @@ Wizard.propTypes = {
 
 Wizard.defaultProps = {
   basename: '',
+  preserveQuery: false,
   history: null,
   onNext: null,
   render: null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a continuation/remake of this [PR](https://github.com/americanexpress/react-albus/pull/43). 
Also addresses issue #36 

## Description
Introduced the `preserveQuery` prop to the `Wizard` component to allow for maintaining search parameters in the URL during navigation. This addition ensures users can maintain state in the URL, enabling deep-linking scenarios and improving user experience.

## Motivation and Context
The `preserveQuery` prop addresses a common use-case where developers want to maintain URL parameters for various reasons, such as sharing links or retaining user settings across navigation.

Addresses issue #36 .

## How Has This Been Tested?
Wrote tests cases using the `enzyme` testing library. Tests handle scenarios listed below.

(Only when the `preserveQuery` prop is passed).

- Ensure that it handles initial path with query
- Ensure that it preserves initial query when navigating to the next step
- Ensure that it preserves initial query when using replace
- Ensure that it works with search params
- Ensure that it does not add params if there were none

Let me know if there's a specific test scenario that I should add.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X] My changes are in sync with the code style of this project.
- [X] There aren't any other open Pull Requests for the same issue/update.
- [X] These changes should be applied to a maintenance branch.
- [X] This change requires cross browser checks.
- [ ] This change adds additional environment variable requirements for react-albus users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using react-albus?
<!--- Please describe how your changes impacts developers using react-albus. -->
Developers now have the option to maintain URL parameters using the `preserveQuery` prop. This enhancement will provide flexibility to developers, ensuring a better user experience in scenarios where URL state needs to be retained.

P.S - I can add an example under `examples/preserve-query` later on. 
